### PR TITLE
Update can_processor.cpp

### DIFF
--- a/src/can_processor.cpp
+++ b/src/can_processor.cpp
@@ -187,7 +187,7 @@ void processCan()
     // Value: Data / 2.0
     if (Message.id == configuration.CanAddresses.HotWater.CurrentTemperature)
     {
-      temp = Message.data[0] / 2.0;
+      temp = Message.data[1] / 2.0;
       ceraValues.Hotwater.TemperatureCurrent = temp;
     }
 


### PR DESCRIPTION
On mixed circuit configurations with HMM module, the hot water current temperature comes over CAN ID 0x221 which has two bytes and the second byte carries the temperature in 1/2 °C steps