### PR TITLE
Update HA discovery publish topic

### DIFF
--- a/src/ha_autodiscovery.cpp
+++ b/src/ha_autodiscovery.cpp
@@ -39,7 +39,7 @@ void CreateAndPublishAutoDiscoverySensorJson(
     doc["val_tpl"] = value_template;
 
     size_t n = serializeJson(doc, buffer);
-    client.publish(configuration.HomeAssistant.StateTopic.c_str(), buffer, n);
+    client.publish(discoveryTopic.c_str(), buffer, n, true);
 }
 
 void SetupAutodiscoveryForAuxSensors()


### PR DESCRIPTION
## Summary
- update the autodiscovery sensor helper to publish its configuration to the discovery topic and retain it

## Testing
- pio run *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691199c95a5c83299db4d12cded4d8b8)